### PR TITLE
Fix build errors in Ubuntu Linux

### DIFF
--- a/clientsamples/cpp/gst-transformer-client.cpp
+++ b/clientsamples/cpp/gst-transformer-client.cpp
@@ -1,3 +1,4 @@
+
 /*
 
 Copyright 2018 technicianted
@@ -23,6 +24,8 @@ all copies or substantial portions of the Software.
 
 #include "client.h"
 #include "clientcli.h"
+
+#include <spdlog/sinks/stdout_sinks.h>
 
 int main(int argc, char **argv)
 {

--- a/clientsamples/cpp/gst-transformer-inproc.cpp
+++ b/clientsamples/cpp/gst-transformer-inproc.cpp
@@ -24,6 +24,7 @@ all copies or substantial portions of the Software.
 #include <grpc++/client_context.h>
 #include <grpc++/server_builder.h>
 #include <spdlog/spdlog.h>
+#include <spdlog/sinks/stdout_sinks.h>
 
 #include "async/asyncserviceimpl.h"
 #include "client.h"

--- a/src/lib/dynamicpipeline.cpp
+++ b/src/lib/dynamicpipeline.cpp
@@ -1,5 +1,6 @@
 #include "dynamicpipeline.h"
 
+#include <spdlog/sinks/stdout_sinks.h>
 #include <spdlog/spdlog.h>
 #include <fmt/format.h>
 #include <unistd.h>
@@ -234,7 +235,7 @@ DynamicPipeline * DynamicPipeline::createFromSpecs(const PipelineParameters &par
     auto pipeline = gst_parse_launch(desc.c_str(), &error);
     if (!pipeline) {
         auto message = fmt::format("could not create pipeline {0}: {1}", pipelineId, error->message);
-        logger->notice(message);
+        logger->error(message);
         g_error_free(error);
         throw std::invalid_argument(message);
     }
@@ -360,7 +361,7 @@ void DynamicPipeline::gstNewSample(GstElement *sink, gpointer user_data)
     gint64 pos;
     auto r = gst_element_query_position(p->pipeline, GST_FORMAT_TIME, &pos);
     if (!r)
-        p->logger->notice("unable to query position");
+        p->logger->error("unable to query position");
     if (pos > p->processedTime)
         p->processedTime = pos;
     if (p->parameters.getLengthLimit() > 0 ) {

--- a/src/lib/dynamicpipeline.cpp
+++ b/src/lib/dynamicpipeline.cpp
@@ -235,7 +235,7 @@ DynamicPipeline * DynamicPipeline::createFromSpecs(const PipelineParameters &par
     auto pipeline = gst_parse_launch(desc.c_str(), &error);
     if (!pipeline) {
         auto message = fmt::format("could not create pipeline {0}: {1}", pipelineId, error->message);
-        logger->error(message);
+        logger->warn(message);
         g_error_free(error);
         throw std::invalid_argument(message);
     }
@@ -361,7 +361,7 @@ void DynamicPipeline::gstNewSample(GstElement *sink, gpointer user_data)
     gint64 pos;
     auto r = gst_element_query_position(p->pipeline, GST_FORMAT_TIME, &pos);
     if (!r)
-        p->logger->error("unable to query position");
+        p->logger->warn("unable to query position");
     if (pos > p->processedTime)
         p->processedTime = pos;
     if (p->parameters.getLengthLimit() > 0 ) {

--- a/src/lib/server/async/asyncserviceimpl.cpp
+++ b/src/lib/server/async/asyncserviceimpl.cpp
@@ -1,5 +1,6 @@
 #include "asyncserviceimpl.h"
 #include "asynctransformimpl.h"
+#include <spdlog/sinks/stdout_sinks.h>
 
 #include <functional>
 

--- a/src/lib/server/async/asynctransformimpl.cpp
+++ b/src/lib/server/async/asynctransformimpl.cpp
@@ -3,7 +3,9 @@
 #include "../serverpipelinefactory.h"
 
 #include <fmt/format.h>
+
 #include <spdlog/spdlog.h>
+#include <spdlog/sinks/stdout_sinks.h>
 
 namespace gst_transformer {
 namespace service {
@@ -61,7 +63,7 @@ void AsyncTransformImpl::setup()
         auto iterator = metadata.find(ClientMetadata_Name(ClientMetadata::requestid));
         if (iterator == metadata.end()) {
             auto message = fmt::format("request ID not set: {0}", ClientMetadata_Name(ClientMetadata::requestid));
-            this->globalLogger->notice(message);
+            this->globalLogger->error(message);
 
             this->responder.Finish(
                 ::grpc::Status(::grpc::StatusCode::FAILED_PRECONDITION, message), 
@@ -79,7 +81,7 @@ void AsyncTransformImpl::setup()
 
     this->startFunction = [&] (bool ok) {
         if (!this->request.has_config()) {
-            this->logger->notice("config message not sent");
+            this->logger->error("config message not sent");
             this->responder.Finish(
                 ::grpc::Status(::grpc::StatusCode::FAILED_PRECONDITION, "config message not sent"), 
                 &this->finishFunction);
@@ -94,7 +96,7 @@ void AsyncTransformImpl::setup()
         }
         catch(std::exception &e) {
             auto message = fmt::format("invalid config: {0}", e.what());
-            logger->notice(message);
+            logger->error(message);
             this->responder.Finish(
                 ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT, message), 
                 &this->finishFunction);
@@ -107,7 +109,7 @@ void AsyncTransformImpl::setup()
         }
         catch(std::exception &e) {
             auto message = fmt::format("cannot create pipeline: {0}", e.what());
-            logger->notice(message);
+            logger->error(message);
             this->responder.Finish(
                 ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT, message), 
                 &this->finishFunction);
@@ -187,7 +189,7 @@ void AsyncTransformImpl::setup()
             if (ok) {
                 if (!this->request.has_payload()) {
                     auto message = "no payload in request message";
-                    logger->notice(message);
+                    logger->error(message);
                     this->responder.Finish(
                         ::grpc::Status(::grpc::StatusCode::FAILED_PRECONDITION, message), &this->finishFunction);
                 }
@@ -197,7 +199,7 @@ void AsyncTransformImpl::setup()
                 for (int i=0; i<payloads.data_size(); i++) {
                     auto data = payloads.data(i);
                     if (pipeline->addData(data.data(), data.size()) == -1) {
-                        logger->notice("pipeline returned error adding data");
+                        logger->error("pipeline returned error adding data");
                         pipelineError = true;
                         break;
                     }
@@ -232,7 +234,7 @@ void AsyncTransformImpl::setup()
             this->logger->trace("writeSampleDoneFunction: done");
         }
         else {
-            this->logger->notice("not ok in write");
+            this->logger->error("not ok in write");
         }
     };
 
@@ -241,7 +243,7 @@ void AsyncTransformImpl::setup()
         if (ok) 
             this->summaryFunction(ok);
         else
-            this->logger->notice("writerRemainderDoneFunction: not ok");
+            this->logger->error("writerRemainderDoneFunction: not ok");
     };
 
     this->summaryFunction = [&] (bool ok) {
@@ -258,7 +260,7 @@ void AsyncTransformImpl::setup()
             this->write(finalResponse, AsyncWriteState::WritingSummary, this->finishSuccessFunction);
         }
         else {
-            this->logger->notice("unable to perform flush write");
+            this->logger->error("unable to perform flush write");
         }
     };
 

--- a/src/lib/server/async/asynctransformimpl.cpp
+++ b/src/lib/server/async/asynctransformimpl.cpp
@@ -63,7 +63,7 @@ void AsyncTransformImpl::setup()
         auto iterator = metadata.find(ClientMetadata_Name(ClientMetadata::requestid));
         if (iterator == metadata.end()) {
             auto message = fmt::format("request ID not set: {0}", ClientMetadata_Name(ClientMetadata::requestid));
-            this->globalLogger->error(message);
+            this->globalLogger->warn(message);
 
             this->responder.Finish(
                 ::grpc::Status(::grpc::StatusCode::FAILED_PRECONDITION, message), 
@@ -81,7 +81,7 @@ void AsyncTransformImpl::setup()
 
     this->startFunction = [&] (bool ok) {
         if (!this->request.has_config()) {
-            this->logger->error("config message not sent");
+            this->logger->warn("config message not sent");
             this->responder.Finish(
                 ::grpc::Status(::grpc::StatusCode::FAILED_PRECONDITION, "config message not sent"), 
                 &this->finishFunction);
@@ -96,7 +96,7 @@ void AsyncTransformImpl::setup()
         }
         catch(std::exception &e) {
             auto message = fmt::format("invalid config: {0}", e.what());
-            logger->error(message);
+            logger->warn(message);
             this->responder.Finish(
                 ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT, message), 
                 &this->finishFunction);
@@ -109,7 +109,7 @@ void AsyncTransformImpl::setup()
         }
         catch(std::exception &e) {
             auto message = fmt::format("cannot create pipeline: {0}", e.what());
-            logger->error(message);
+            logger->warn(message);
             this->responder.Finish(
                 ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT, message), 
                 &this->finishFunction);
@@ -189,7 +189,7 @@ void AsyncTransformImpl::setup()
             if (ok) {
                 if (!this->request.has_payload()) {
                     auto message = "no payload in request message";
-                    logger->error(message);
+                    logger->warn(message);
                     this->responder.Finish(
                         ::grpc::Status(::grpc::StatusCode::FAILED_PRECONDITION, message), &this->finishFunction);
                 }
@@ -199,7 +199,7 @@ void AsyncTransformImpl::setup()
                 for (int i=0; i<payloads.data_size(); i++) {
                     auto data = payloads.data(i);
                     if (pipeline->addData(data.data(), data.size()) == -1) {
-                        logger->error("pipeline returned error adding data");
+                        logger->warn("pipeline returned error adding data");
                         pipelineError = true;
                         break;
                     }
@@ -234,7 +234,7 @@ void AsyncTransformImpl::setup()
             this->logger->trace("writeSampleDoneFunction: done");
         }
         else {
-            this->logger->error("not ok in write");
+            this->logger->warn("not ok in write");
         }
     };
 
@@ -243,7 +243,7 @@ void AsyncTransformImpl::setup()
         if (ok) 
             this->summaryFunction(ok);
         else
-            this->logger->error("writerRemainderDoneFunction: not ok");
+            this->logger->warn("writerRemainderDoneFunction: not ok");
     };
 
     this->summaryFunction = [&] (bool ok) {
@@ -260,7 +260,7 @@ void AsyncTransformImpl::setup()
             this->write(finalResponse, AsyncWriteState::WritingSummary, this->finishSuccessFunction);
         }
         else {
-            this->logger->error("unable to perform flush write");
+            this->logger->warn("unable to perform flush write");
         }
     };
 

--- a/src/server/servercli.cpp
+++ b/src/server/servercli.cpp
@@ -50,7 +50,7 @@ void usage()
 	std::cerr << "Usage: gsttransformerserver [OPTION...] [<endpoint>]" << std::endl;
     std::cerr << "  -c FILE\tjson configuration file." << std::endl;
     std::cerr << "     env: GSTTRANSFORMER_CONFIG_PATH" << std::endl;
-	std::cerr << "  -d LEVEL\tDebug level {trace|debug|info|notice|error}." << std::endl;
+	std::cerr << "  -d LEVEL\tDebug level {trace|debug|info|warn|error}." << std::endl;
     std::cerr << "     env: GSTTRANSFORMER_LOG_LEVEL" << std::endl;
     std::cerr << "endpoint: grpc style endpoint" << std::endl;
     std::cerr << "  env: GSTTRANSFORMER_ENDPOINT" << std::endl;

--- a/src/server/serviceparams.cpp
+++ b/src/server/serviceparams.cpp
@@ -2,6 +2,7 @@
 
 #include <fmt/format.h>
 #include <fstream>
+#include <sstream>
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
 


### PR DESCRIPTION
Latest version of spdlog on Ubuntu doesn't support notice(), so switch to error() instead.  Also, add a few header includes needed to get the build to succeed.